### PR TITLE
Fix not correctly disabling interrupts in reset

### DIFF
--- a/comms/px_one_wire.c
+++ b/comms/px_one_wire.c
@@ -127,7 +127,8 @@ void px_one_wire_init(void)
 bool px_one_wire_reset(void)
 {
     bool presence_detected;
-
+    
+    PX_ONE_WIRE_CFG_INTS_DISABLE();
     PX_ONE_WIRE_CFG_PIN_SET_LO();
     PX_ONE_WIRE_CFG_DELAY_US(480);
     PX_ONE_WIRE_CFG_PIN_DIR_SET_IN();
@@ -144,6 +145,7 @@ bool px_one_wire_reset(void)
         // No
         presence_detected = false;
     }
+    PX_ONE_WIRE_CFG_INTS_ENABLE();
     PX_ONE_WIRE_CFG_DELAY_US(410);
 
     return presence_detected;


### PR DESCRIPTION
The px_one_wire_reset function didn't correctly disable interrupts