### PR TITLE
add peek, free and full to ring buf

### DIFF
--- a/utils/px_ring_buf.c
+++ b/utils/px_ring_buf.c
@@ -166,3 +166,90 @@ px_ring_buf_idx_t px_ring_buf_rd(px_ring_buf_t * px_ring_buf,
 
     return bytes_read;
 }
+
+px_ring_buf_idx_t px_ring_buf_peek(px_ring_buf_t * px_ring_buf, 
+                                 void *          data,
+                                 size_t          nr_of_bytes_to_peek,
+                                 size_t          nr_of_bytes_to_skip)
+{
+    px_ring_buf_idx_t bytes_read     = 0;
+    px_ring_buf_idx_t current_rd_idx = px_ring_buf->rd;
+    uint8_t *         data_u8        = (uint8_t *)data;
+    px_ring_buf_idx_t full           = px_ring_buf_full(px_ring_buf);
+    
+    if (nr_of_bytes_to_skip >= full)
+    {
+        return 0;
+    }
+
+    while (nr_of_bytes_to_skip)
+    {
+        current_rd_idx = px_ring_buf_next(px_ring_buf, current_rd_idx);
+        nr_of_bytes_to_skip--;
+    }
+
+    while(nr_of_bytes_to_peek)
+    {
+        // See if there is data in the buffer
+        if (current_rd_idx == px_ring_buf->wr)
+        {
+            // Buffer is empty
+            break;
+        }
+        // Fetch data
+        *data_u8++ = px_ring_buf->buf[current_rd_idx];
+        // Advance index
+        current_rd_idx = px_ring_buf_next(px_ring_buf, current_rd_idx);
+        // Next byte
+        bytes_read++;
+        nr_of_bytes_to_peek--;
+    }
+
+    return bytes_read;
+}
+
+px_ring_buf_idx_t px_ring_buf_free(px_ring_buf_t * px_ring_buf)
+{
+    px_ring_buf_idx_t size;
+    
+    px_ring_buf_idx_t wr = px_ring_buf->wr;
+    px_ring_buf_idx_t rd = px_ring_buf->rd;
+
+    if (wr == rd)
+    {
+        size = px_ring_buf->buf_size;
+    }
+    else if (rd > wr)
+    {
+        size = rd - wr;
+    }
+    else {
+        size = px_ring_buf->buf_size - (wr - rd);
+    }
+
+    // Free size is always 1 less than actual size for this implementation
+    return size - 1;
+}
+
+px_ring_buf_idx_t px_ring_buf_full(px_ring_buf_t * px_ring_buf)
+{
+    px_ring_buf_idx_t size;
+    
+    px_ring_buf_idx_t wr = px_ring_buf->wr;
+    px_ring_buf_idx_t rd = px_ring_buf->rd;
+
+    if (wr == rd)
+    {
+        size = 0;
+    }
+    else if (wr > rd)
+    {
+        size = wr - rd;
+    }
+    else
+    {
+        size = px_ring_buf->buf_size - (rd - wr);
+    }
+
+    return size;
+}

--- a/utils/px_ring_buf.h
+++ b/utils/px_ring_buf.h
@@ -207,6 +207,43 @@ px_ring_buf_idx_t px_ring_buf_rd(px_ring_buf_t * px_ring_buf,
                                  void *          data,
                                  size_t          nr_of_bytes_to_rd);
 
+
+/** 
+ * Peek data from the circular buffer, without advancing the read pointer.
+ *  
+ * @param px_ring_buf           Pointer to the circular buffer object
+ * @param data                  Pointer to location where data must be stored
+ * @param nr_of_bytes_to_peek   Number of bytes to peek    
+ * @param nr_of_bytes_to_peek   Number of bytes to skip, before peeking    
+ *  
+ * @return px_ring_buf_idx_t    The actual number of bytes peeked, which may 
+ *                              be less than the number specified, because the 
+ *                              buffer is empty.
+ */
+px_ring_buf_idx_t px_ring_buf_peek(px_ring_buf_t * px_ring_buf, 
+                                 void *          data,
+                                 size_t          nr_of_bytes_to_peek,
+                                 size_t          nr_of_bytes_to_skip);
+
+
+
+/** 
+ * Get free bytes available in buffer, an empty buffer has one less byte than the size
+ *  
+ * @param px_ring_buf           Pointer to the circular buffer object
+ * @return px_ring_buf_idx_t    The actual number of bytes available in the buffer
+ */
+px_ring_buf_idx_t px_ring_buf_free(px_ring_buf_t * px_ring_buf);
+
+
+/** 
+ * Get the number of bytes in the buffer, how full is the buffer?
+ *  
+ * @param px_ring_buf           Pointer to the circular buffer object
+ * @return px_ring_buf_idx_t    The actual number of bytes in the buffer
+ */
+px_ring_buf_idx_t px_ring_buf_full(px_ring_buf_t * px_ring_buf);
+
 /* _____MACROS_______________________________________________________________ */
 
 /// @}


### PR DESCRIPTION
Some useful utility functions:

- **Peek**: Read without advancing, you can skip bytes before you peek, if you skip more than the size of the buffer you won't be able to read anything. 

- **Free**: How many bytes can we write

- **Full**: How many bytes can we read